### PR TITLE
Add support for Flask 2.0

### DIFF
--- a/dmcontent/__init__.py
+++ b/dmcontent/__init__.py
@@ -2,4 +2,4 @@ from .content_loader import ContentLoader
 from .errors import ContentTemplateError, QuestionNotFoundError
 from .questions import ContentQuestion
 
-__version__ = '9.0.0'
+__version__ = '9.1.0'

--- a/dmcontent/govuk_frontend.py
+++ b/dmcontent/govuk_frontend.py
@@ -611,20 +611,20 @@ def render(ctx, obj: Renderable, *, question=None) -> Markup:
 
                 visit(params)
 
-                inner_html += Markup(macro(params))
+                inner_html += Markup(macro(params))  # type:ignore # fix once drop support for Flask 1.0
             else:
-                inner_html += Markup(macro())
+                inner_html += Markup(macro())  # type:ignore # fix once drop support for Flask 1.0
 
             if "fieldset" in obj:
                 inner_html = Markup(
                     ctx.resolve("govukFieldset")(obj["fieldset"], caller=lambda: inner_html)
                 )
 
-            html += inner_html
+            html += inner_html  # type:ignore # fix once drop support for Flask 1.0
 
         return html
     elif isinstance(obj, (str, Markup)):
-        return escape(obj)
+        return escape(obj)  # type:ignore # fix once drop support for Flask 1.0
     else:
         raise TypeError("render() expects a dict or string type, or a list of dicts or string types")
 

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ setup(
     package_data={'dmcontent': ['py.typed']},
     include_package_data=True,
     install_requires=[
-        'Flask~=1.0',
-        'Jinja2~=2.10',
+        'Flask>=1.0,<2.1',
+        'Jinja2>=2.10,<3.1',
         'Markdown<4.0.0,>=2.6.7',
         'PyYAML>=5.1.2,<7.0',
         'inflection<1.0.0,>=0.3.1',

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,5 @@ setup(
         'inflection<1.0.0,>=0.3.1',
         'digitalmarketplace-utils>=59.0.0',
     ],
-    python_requires="~=3.6",
+    python_requires="~=3.8",
 )

--- a/tests/test_govuk_frontend.py
+++ b/tests/test_govuk_frontend.py
@@ -1,3 +1,4 @@
+import markupsafe
 import pytest
 
 from unittest import mock
@@ -1257,10 +1258,10 @@ class TestRender:
         return env
 
     def test_it_returns_markup(self, context):
-        assert isinstance(render(context, []), Markup)
-        assert isinstance(render(context, ""), Markup)
-        assert isinstance(render(context, "Hello World"), Markup)
-        assert isinstance(render(context, Markup("<p>Hello World</p>")), Markup)
+        assert isinstance(render(context, []), (Markup, markupsafe.Markup))
+        assert isinstance(render(context, ""), (Markup, markupsafe.Markup))
+        assert isinstance(render(context, "Hello World"), (Markup, markupsafe.Markup))
+        assert isinstance(render(context, Markup("<p>Hello World</p>")), (Markup, markupsafe.Markup))
 
     def test_it_returns_the_empty_string_if_called_with_nothing(self, context):
         assert render(context, []) == ""

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 from collections import OrderedDict
 
+import markupsafe
 from markupsafe import Markup
 import pytest
 import six
@@ -131,7 +132,7 @@ class QuestionTest(object):
             if hasattr(question, field):
                 for item in question[field]:
                     if subfield in item:
-                        assert type(item[subfield]) == Markup
+                        assert isinstance(item[subfield], (Markup, markupsafe.Markup))
 
     def test_question_has_href_property(self):
         question = self.question()


### PR DESCRIPTION
https://trello.com/c/oWvOqn00/2276-upgrade-to-flask-v2

We'd like to be able to upgrade to Flask 2.0 because it promises performance improvements that might be handy to us.

Fix up some minor typing problems caused by Flask 2.0. We'll be able to fix it all up properly once we drop support for Flask 1.0.

I've tested that this works fine with both Flask 1.x and 2.0